### PR TITLE
Catch JSONDecodeError on empty API responses

### DIFF
--- a/src/bwt_api/api.py
+++ b/src/bwt_api/api.py
@@ -41,7 +41,10 @@ class BwtApi:
             async with self._session.get(f"http://{self._host}:8080/api/{endpoint}") as response:
                 _logger.debug(f"Response status: {response.status}, content-type: {response.headers['content-type']}")
                 if (response.status == 200):
-                    json = await response.json(content_type=None)
+                    try:
+                        json = await response.json(content_type=None)
+                    except ValueError as e:
+                        raise ApiException(f"Invalid JSON response from {endpoint}") from e
                     _logger.debug(f"Raw response: {json}")
                     return json
                 else:
@@ -161,7 +164,10 @@ class BwtSilkApi:
             async with self._session.get(f"http://{self._host}:80/silk/registers") as response:
                 _logger.debug(f"Response status: {response.status}, content-type: {response.headers['content-type']}")
                 if (response.status == 200):
-                    json = await response.json(content_type=None)
+                    try:
+                        json = await response.json(content_type=None)
+                    except ValueError as e:
+                        raise ApiException(f"Invalid JSON response from silk/registers") from e
                     _logger.debug(f"Raw response: {json}")
                     return json["params"]
                 else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,6 +148,15 @@ async def test_unknown_response():
                 await api.get_current_data()
 
 
+async def test_empty_response():
+    """HTTP 200 with empty body should raise ApiException, not JSONDecodeError."""
+    with aioresponses() as mocked:
+        mocked.get("http://host:8080/api/GetCurrentData", status=200, body="not json")
+        async with BwtApi("host", "code") as api:
+            with pytest.raises(ApiException):
+                await api.get_current_data()
+
+
 async def test_current_data():
     with aioresponses() as mocked:
         mocked.get("http://host:8080/api/GetCurrentData", status=200, body=current_json)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,8 +148,8 @@ async def test_unknown_response():
                 await api.get_current_data()
 
 
-async def test_empty_response():
-    """HTTP 200 with empty body should raise ApiException, not JSONDecodeError."""
+async def test_invalid_json_response():
+    """HTTP 200 with non-JSON body should raise ApiException, not JSONDecodeError."""
     with aioresponses() as mocked:
         mocked.get("http://host:8080/api/GetCurrentData", status=200, body="not json")
         async with BwtApi("host", "code") as api:


### PR DESCRIPTION
When the BWT device returns HTTP 200 with an empty body, `response.json()` raises `JSONDecodeError` which is not caught by the `ClientConnectorError` handler. This causes unhandled tracebacks in callers (see dkarv/ha-bwt-perla#32).

This wraps the `json()` calls in both `BwtApi` and `BwtSilkApi` and converts the error to `ApiException`, so callers can handle it uniformly via the `BwtException` hierarchy.