### PR TITLE
Fix operator precedence bug in treated_to_blended

### DIFF
--- a/src/bwt_api/api.py
+++ b/src/bwt_api/api.py
@@ -173,7 +173,7 @@ class BwtSilkApi:
 
 
 def treated_to_blended(treated: int, hardness_in: int, hardness_out: int) -> float:
-    if (hardness_in == 0 | hardness_in == hardness_out):
+    if hardness_in == 0 or hardness_in == hardness_out:
         return treated
 
     return treated / (1.0 - hardness_out / hardness_in)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -263,3 +263,5 @@ def test_treated_to_blended():
     assert treated_to_blended(10, 20, 4) == 12.5
     assert treated_to_blended(306, 21, 4) == 378
     assert treated_to_blended(191, 21, 4) == pytest.approx(235.9411)
+    # Edge case: hardness_in == 0 should return treated as-is, not divide by zero
+    assert treated_to_blended(100, 0, 0) == 100


### PR DESCRIPTION
The bitwise OR `|` binds tighter than `==`, so the guard condition `hardness_in == 0 | hardness_in == hardness_out` evaluates as `hardness_in == (0 | hardness_in) == hardness_out` — a chained comparison that almost never triggers. This means the division-by-zero guard for `hardness_in == 0` doesn't work, and the `hardness_in == hardness_out` shortcut is also ineffective.

Fix: replace `|` with `or`.