### PR TITLE
Fix BwtError.UNKNOWN singleton mutation on unknown error codes

### DIFF
--- a/src/bwt_api/api.py
+++ b/src/bwt_api/api.py
@@ -66,7 +66,7 @@ class BwtApi:
         _logger.debug(f"Fetching current data from {self._host}")
         raw = await self.__get_data("GetCurrentData")
         errors = [BwtError(int(error)) for error in raw["ActiveErrorIDs"].split(",") if error]
-        if BwtError.UNKNOWN in errors:
+        if any(e.name.startswith("UNKNOWN") for e in errors):
             _logger.warning(f"Unknown error in current data response {raw['ActiveErrorIDs']}")
         perla_one = raw["CapacityColumn2_ml_dH"] == -1
         

--- a/src/bwt_api/error.py
+++ b/src/bwt_api/error.py
@@ -57,9 +57,18 @@ class BwtError(enum.Enum):
 
     @classmethod
     def _missing_(cls, value):
-        obj = cls.UNKNOWN
+        obj = object.__new__(cls)
         obj._value_ = value
+        obj._name_ = f"UNKNOWN_{value}"
         return obj
+
+    def __eq__(self, other):
+        if isinstance(other, BwtError):
+            return self._value_ == other._value_
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self._value_)
 
     def is_fatal(self) -> bool:
         return self not in WARNING_CODES

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,7 +158,7 @@ async def test_current_data():
                     BwtError.REGENERATIV_20,
                     BwtError.MAINTENANCE_CUSTOMER,
                     BwtError.MAINTENANCE_SERVICE,
-                    BwtError.UNKNOWN,
+                    BwtError(29),
                 ],
                 blended_total=318383,
                 capacity_1=5485275,
@@ -256,6 +256,20 @@ async def test_perla_one():
                 treated_year=500,
                 columns=1,
             )
+
+def test_unknown_error_no_mutation():
+    """Unknown error codes must not mutate the UNKNOWN singleton."""
+    err1 = BwtError(29)
+    assert err1.value == 29
+    assert err1.name == "UNKNOWN_29"
+    err2 = BwtError(123)
+    assert err2.value == 123
+    assert err2.name == "UNKNOWN_123"
+    # UNKNOWN singleton must be untouched
+    assert BwtError.UNKNOWN.value == -1
+    # Different unknown codes produce different instances
+    assert err1 is not err2
+
 
 def test_treated_to_blended():
     assert treated_to_blended(0, 21, 4) == 0


### PR DESCRIPTION
`_missing_()` reuses the `UNKNOWN` singleton and overwrites its `_value_`, so successive unknown error codes leak state across calls. After `BwtError(29)`, `BwtError.UNKNOWN.value` is `29` instead of `-1`.

Now each unknown code gets its own instance with a descriptive name (e.g. `UNKNOWN_29`) and value-based equality, leaving the `UNKNOWN` sentinel untouched.