### PR TITLE
Normalize TimeoutError to ConnectException

### DIFF
--- a/src/bwt_api/api.py
+++ b/src/bwt_api/api.py
@@ -52,7 +52,7 @@ class BwtApi:
                     else:
                         _logger.warning(f"Unknown response with status {response.status}: {text}")
                         raise ApiException(f"Unknown response: {text}")
-        except aiohttp.ClientConnectorError as e:
+        except (aiohttp.ClientConnectorError, TimeoutError) as e:
             raise ConnectException from e
 
     def _convert_datetime(self, input: str) -> datetime:
@@ -168,7 +168,7 @@ class BwtSilkApi:
                     text = await response.text()
                     _logger.warning(f"Unknown response with status {response.status}: {text}")
                     raise ApiException(f"Unknown response: {text}")
-        except aiohttp.ClientConnectorError as e:
+        except (aiohttp.ClientConnectorError, TimeoutError) as e:
             raise ConnectException from e
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,6 +140,15 @@ async def test_connect_error():
             await api.get_current_data()
 
 
+async def test_timeout_error():
+    """Timeouts should be wrapped as ConnectException, not escape as raw TimeoutError."""
+    with aioresponses() as mocked:
+        mocked.get("http://host:8080/api/GetCurrentData", exception=TimeoutError())
+        async with BwtApi("host", "code") as api:
+            with pytest.raises(ConnectException):
+                await api.get_current_data()
+
+
 async def test_unknown_response():
     with aioresponses() as mocked:
         mocked.get("http://host:8080/api/GetCurrentData", status=400, body="")


### PR DESCRIPTION
Both API wrappers only catch `aiohttp.ClientConnectorError`, so a timeout escapes as raw `TimeoutError` instead of `ConnectException`. Callers expecting `ConnectException` (or its parent `BwtException`) miss it.

Adds `TimeoutError` to the except clause in both `BwtApi.__get_data()` and `BwtSilkApi.get_registers()`.